### PR TITLE
Add keti alias

### DIFF
--- a/kube-aliases.plugin.zsh
+++ b/kube-aliases.plugin.zsh
@@ -204,7 +204,7 @@ alias kgsy='kubectl get services -o yaml'
 alias kgss='kubectl get statefulsets'
 
 # Execute a command in a specified pod, default drops user into the shell
-alias keti='kubectl exec -it'
+alias keit='kubectl exec -it'
 
 kcexec () {
   kubectl exec -it $1 ${2:-bash}

--- a/kube-aliases.plugin.zsh
+++ b/kube-aliases.plugin.zsh
@@ -204,6 +204,8 @@ alias kgsy='kubectl get services -o yaml'
 alias kgss='kubectl get statefulsets'
 
 # Execute a command in a specified pod, default drops user into the shell
+alias keti='kubectl exec -it'
+
 kcexec () {
   kubectl exec -it $1 ${2:-bash}
 }


### PR DESCRIPTION
`kcexec` and `kexec` aliases have the problem that they cant autocomplete the pod name because they are hidden inside a function. In addition in case the pod contains multiple containers, its impossible to specify the container.