### PR TITLE
Update kubectl exec commands

### DIFF
--- a/kube-aliases.plugin.zsh
+++ b/kube-aliases.plugin.zsh
@@ -204,13 +204,13 @@ alias kgsy='kubectl get services -o yaml'
 alias kgss='kubectl get statefulsets'
 
 # Execute a command in a specified pod, default drops user into the shell
-alias keit='kubectl exec -it'
+alias keit='kubectl exec -it -- '
 
 kcexec () {
-  kubectl exec -it $1 ${2:-bash}
+  kubectl exec -it $1 -- ${2:-bash}
 }
 kexec () {
-  kubectl exec -it $1 ${2:-bash}
+  kubectl exec -it $1 -- ${2:-bash}
 }
 
 # Set and use a new context

--- a/kube-aliases.plugin.zsh
+++ b/kube-aliases.plugin.zsh
@@ -204,7 +204,7 @@ alias kgsy='kubectl get services -o yaml'
 alias kgss='kubectl get statefulsets'
 
 # Execute a command in a specified pod, default drops user into the shell
-alias keit='kubectl exec -it -- '
+alias keit='kubectl exec -it --'
 
 kcexec () {
   kubectl exec -it $1 -- ${2:-bash}


### PR DESCRIPTION
Current syntax for the kubectl exec command is deprecated, running kexec
gives the following warning in v1.20.4 of kubectl:
```kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.```