### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ request.
 ### Oh-My-Zsh
 
 ```
-git clone git@github.com:Dbz/kube-aliases.git ~/.oh-my-zsh/custom/plugins/kube-aliases
+git clone https://github.com/Dbz/kube-aliases.git ~/.oh-my-zsh/custom/plugins/kube-aliases
 echo "plugins+=(kube-aliases)" >> ~/.zshrc
 ```
 


### PR DESCRIPTION
Use Git with HTTPS for cloning repo instead of Git SSH. As with SSH it might return repo not found if git SSH is not configured.

![image](https://user-images.githubusercontent.com/23054298/125232843-5723d200-e292-11eb-9a94-a59a0fb6b7b8.png)

Reference:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/error-repository-not-found
